### PR TITLE
Update README: removendo duplicações e organizando links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,44 +5,14 @@ Este repositório contém todos os projetos já desenvolvidos no LHC.
 
 # Projetos
 
-- nodeLHC
-- nodeLHC-ESP32
-- LHCbit
+- [nodeLHC](https://github.com/lhc/Hardware/tree/main/nodeLHC)
+- [nodeLHC-ESP32](https://github.com/lhc/Hardware/tree/main/nodeLHC-ESP32)
+- [LHCbit](https://github.com/lhc/Hardware/tree/main/LHCbit)
 
 # Oficinas
 
-Página do Evento: https://eventos.lhc.net.br/event/live-construindo-sua-placa-em-kicad
+- [Evento: Construindo sua placa em KiCad](https://github.com/lhc/Hardware/tree/main/Oficinas/monte-sua-placa-kicad)
 
 # Bibliotecas
 
-- Biblioteca desenvolvida durante oficina Construindo sua placa em Kicad
-
-![LHCbit](LHCbit/Imagens/pcb-LHCbit-00.jpeg)
-![LHCbit](LHCbit/Imagens/pcb-LHCbit-01.jpeg)
-![LHCbit](LHCbit/Imagens/pcb-LHCbit-02.jpeg)
-
-# Checklist Review 0.1
-- O VCC e GND estava em curto, revisado por Leandro Pereira
-
-# Checklist Review 0.2
-
-| Itens           | Check | Double Check  |
-|---------------------|----------|----------|
-| Alimentação 3V3|  |  |
-| LoRa RAK3172-SiP|  |  |
-| Reset e Boot|  |  |
-| USB Type C |  |  |
-| OLED|  |  |
-| ESP32-S3-16R8 pinout|  |  |
-
-![LHCbit](LHCBit/Imagens/BOM-LHCbit.png)
-- [x] [BOM](LHCbit/Templates/BOM%20Default%20Template.xlsx)
-
-
-
-# Oficina de apresentação do projeto
-- [definindo] eventos.lhc.net.br
-
-  
-# LOG
-- 25/04/2024 update README
+- [KiCad LHC](https://github.com/lhc/Hardware/tree/main/Libraries/lhc_kicad_library)


### PR DESCRIPTION
Informações da LHCbit estavam duplicadas no README principal. 